### PR TITLE
Update to video protection details

### DIFF
--- a/docs/features/video-protection.md
+++ b/docs/features/video-protection.md
@@ -1,9 +1,10 @@
 # Video Protection
 
-Videos can be protected in JW platform in two ways:
+Videos can be protected in JW platform in three ways:
 
 - **Signed URLs:** A player can only **access** video URLs from JW Player backend using a time-bound JWT token
-- **DRM:** A player can only **play** videos using a time-bound decryption key. 
+- **HLS AES-128 Encryption:** A player can only **play** videos using a decryptoin key.
+- **DRM:** A player can only **play** videos using a decryption key that is provided if the DRM Policy is met. 
 
 The  JW Web Player, as well as the other SDKs, supports these mechanismns out-the-box. However this requires a server side authorization service which is **NOT** part of the web app and needs to be **custom developed**.
 


### PR DESCRIPTION
AES-128 encryption was missing from this document. I added it. More details here: https://developer.jwplayer.com/jwplayer/docs/jw8-enable-aes-decryption
Also, the mechanism for DRM is more than a timed-bound decryption key. There are DRM policies that need to be met and once they are met they are provided the key. And within those policies it will determine how long the end-user has access. In some cases, it could be forever, e.g. if they purchases the media.

## Description

<!-- Describe the proposed solution/fix/feature in this pull request here. -->

This PR solves # .

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] User stories met
- [ ] Storybook stories
- [ ] Unit tests added
- [ ] Linting passing
- [ ] Unit tests passing
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
